### PR TITLE
Fix index and minor documentation additions

### DIFF
--- a/.github/workflows/asciidoctor-build.yml
+++ b/.github/workflows/asciidoctor-build.yml
@@ -20,7 +20,7 @@ jobs:
       id: adocbuild
       uses: avattathil/asciidoctor-action@master
       with:
-           program: "gem install asciidoctor-multipage; asciidoctor -r asciidoctor-multipage -b multipage_html5 -D docs README.adoc  -o index.html"
+           program: "gem install asciidoctor-multipage; asciidoctor -r asciidoctor-multipage -b multipage_html5 -D docs index.adoc  -o index.html"
 #          program: "asciidoctor -D docs --backend=html5 -o index.html README.adoc"
 
     - name: Deploy docs to ghpages

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 default:
-	asciidoctor -r asciidoctor-multipage -b multipage_html5 -D docs README.adoc -o index.html
+	asciidoctor -r asciidoctor-multipage -b multipage_html5 -D docs index.adoc -o index.html
 	#asciidoctor -D . --backend=html5 -o index.html README.adoc
 	#asciidoctor-chunker index.html -o publish --depth 2 --titlePage "Cloudera-Labs"

--- a/content/guides/developers.adoc
+++ b/content/guides/developers.adoc
@@ -572,6 +572,23 @@ aws_profile: my-aws-profile
 
 NOTE: You will likely have to re-login to SSO before each run
 
+==== Working with named credential profiles
+
+For CDP, AWS, and other credential-based access controls it is common to have multiple accounts that may be used from time to time. As such, it is useful to be able to easily, safely, and precisely switch between these accounts.
+
+This is typically achieved through use of multiple named profiles, a good introductory guide to this is https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html[here] for AWS.
+
+To set up a named profile for CDP, follow https://docs.cloudera.com/cdp/latest/cli/topics/mc-cli-generating-an-api-access-key.html[this] guide to create an API access key, and then https://docs.cloudera.com/cdp/latest/cli/topics/mc-configuring-cdp-client-with-the-api-access-key.html[this] guide to configure your local credentials by simply adding the `--profile <profile name>` flag to the commands
+
+Credentials are typically stored in a dot-prefix directory in the user profile on Linux, and in the user home directory on Windows, e.g. `~/.aws/credentials`, `~/.cdp/credentials` etc. They may be directly edited in these files if you prefer instead of using the `configure` CLI commands.
+
+By default, Cloudera-Deploy will use the `default` profiles for each account touched, you can set the Definition yaml keys `cdp_profile: <profile name>` and/or `aws_profile: <profile name>` to use a specific named profile instead.
+
+.Things to know:
+
+* There should always be a `default` credential which points to a 'safe' account for when you deliberately or accidentally run commands without specifying a profile. This is generally a dev account, or even an expired credential, to ensure you don't accidentally delete prod.
+* It is typical with CDP Public Cloud to pair a CDP Tenant with specific Cloud Infrastructure accounts to avoid confusion, therefore if you have a `dev` and `prod` CDP tenant with profiles of the same name, we recommend the paired cloud infrastructure accounts are also named `dev` and `prod`.
+
 ==== Using a Jumpbox
 
 A common deployment scenario is to funnel all cluster access through a jump/bastion host.

--- a/content/references/definitionsreference.adoc
+++ b/content/references/definitionsreference.adoc
@@ -92,6 +92,6 @@ However, once you have set those defaults, you will likely want to describe the 
 
 There are several examples given within cloudera-deploy, such as the Sandbox, a CML Workshop, or all the Cloudera DataFlow services. These are all primarily public cloud examples, although the Sandbox does include a basic private cloud cluster as well.
 
-Generally, CDP Public cloud parameters follow a simple structure of some top-level key triggering a particular component to be deployed, along with whatever dependencies it needs, and then any child keys under that top-level key controlling some override of some default. These keys are explained in link:cdp_public.adoc[CDP Public Definition Keys].
+Generally, CDP Public cloud parameters follow a simple structure of some top-level key triggering a particular component to be deployed, along with whatever dependencies it needs, and then any child keys under that top-level key controlling some override of some default. These keys are explained in xref:cdSchemaReference[CDP Public Definition Keys].
 
 Generally, CDP Private Cloud is a more haphazard structure, simply because it is extremely configurable with nearly a decade of history and backwards compatibility, and therefore trying to constrain it to a pretty structure causes more problems than it fixes within the automation.

--- a/content/references/schemareference.adoc
+++ b/content/references/schemareference.adoc
@@ -68,9 +68,11 @@ You should use tags to identify your services to make it easy to track and remov
 [source,yaml]
 tags:
   owner: dchaffelson@cloudera.com
-  enddate: "01012022"
+  enddate: "01312022"
 
 IMPORTANT: The two-space indent of the tag `key: value` pairs is critical for correct YAML structure
+
+NOTE: For backwards compatibility reasons, we give the example date above in American or 'Freedom' format of MMDDYYYY. We recommend most people use ISO8601 or YYYYMMDD format.
 
 ===== Cloud Infrastructure
 
@@ -174,7 +176,7 @@ admin_password: Mysecretpword1!
 name_prefix: cldr
 tags:
   owner: dchaffelson@cloudera.com
-  enddate: "01012022"
+  enddate: "01312022"
 infra_type: aws
 infra_region: us-east-1
 gcloud_credential_file: '~/.config/gcloud/mycreds.json'
@@ -293,6 +295,7 @@ infra:
   aws:
     profile:
     region:
+    arn_partition:
     vpc:
       az_count:
       internet_gateway:

--- a/index.adoc
+++ b/index.adoc
@@ -2,7 +2,6 @@
 :doctype: book
 :docinfo: shared
 :data-uri:
-:title: Documentation for Cloudera-Labs
 :toc: left
 :toclevels: 3
 :sectanchors:


### PR DESCRIPTION
Output is required to be index.html for gh-pages, not README
Corrected some asciidoc links to named sections instead of base file
Added guidance for creating named credential profiles
Clarified that the enddate tag example is in American date format

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>